### PR TITLE
Temp Directory Usage

### DIFF
--- a/tsut/api.py
+++ b/tsut/api.py
@@ -3,6 +3,7 @@ import logging
 import requests
 import sys
 import time
+import tempfile
 
 from .model import User, Group, UsersAndGroups
 
@@ -382,7 +383,12 @@ class SyncUserAndGroups(BaseApiInterface):
         logging.info("%s" % json_str)
         json.loads(json_str)  # do a load to see if it breaks due to bad JSON.
 
-        tmp_file = "/tmp/ug.json.%d" % time.time()
+        # FIX. MB 04/11/2019: Use the tempfile module to locate the temp folder cross platform as this will
+        # be different on Mac/Linux/Win etc
+        logging.debug("Using temp folder:"+tempfile.gettempdir())
+        tmp_file = tempfile.gettempdir()+"/ug.json.%d" % time.time()
+        # tmp_file = "/tmp/ug.json.%d" % time.time()
+
         with open(tmp_file, "w") as out:
             out.write(json_str)
 

--- a/tsut/api.py
+++ b/tsut/api.py
@@ -383,11 +383,9 @@ class SyncUserAndGroups(BaseApiInterface):
         logging.info("%s" % json_str)
         json.loads(json_str)  # do a load to see if it breaks due to bad JSON.
 
-        # FIX. MB 04/11/2019: Use the tempfile module to locate the temp folder cross platform as this will
-        # be different on Mac/Linux/Win etc
+        # Get the temp folder from the environment settings, so it will work cross platform.
         logging.debug("Using temp folder:"+tempfile.gettempdir())
-        tmp_file = tempfile.gettempdir()+"/ug.json.%d" % time.time()
-        # tmp_file = "/tmp/ug.json.%d" % time.time()
+        tmp_file = tempfile.gettempdir() + "/ug.json.%d" % time.time()
 
         with open(tmp_file, "w") as out:
             out.write(json_str)

--- a/tsut/apps.py
+++ b/tsut/apps.py
@@ -154,7 +154,7 @@ class TSUGSyncReader(TSUGReader):
         sync = SyncUserAndGroups(tsurl=args.ts_url, username=args.username,
                                  password=args.password, disable_ssl=args.disable_ssl)
         ugs = sync.get_all_users_and_groups()
-        print(ugs.to_json())
+        #print(ugs.to_json())
         return ugs
 
 


### PR DESCRIPTION
The original version only works on Mac/Linux based platforms as it assumes the temp folder to be /tmp. This won't work on windows for example.

This fix will determine the temp folder in use from the environmental variables and settings in the following order:
1) The directory named by the TMPDIR environment variable.
2) The directory named by the TEMP environment variable.
3) The directory named by the TMP environment variable.
4) A platform-specific location:
On RiscOS, the directory named by the Wimp$ScrapDir environment variable.
On Windows, the directories C:\TEMP, C:\TMP, \TEMP, and \TMP, in that order.
On all other platforms, the directories /tmp, /var/tmp, and /usr/tmp, in that order.
5) As a last resort, the current working directory.